### PR TITLE
Support path recursion via process.mainModule.paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ npm-debug.log
 .directory
 ._*
 lcov.info
+.history
+.vscode
 
 # Runtime data
 pids

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const getInstalledPath = require('get-installed-path')
 
 ## API
 
-### [getInstalledPath](index.js#L70)
+### [getInstalledPath](index.js#L82)
 > Get installed path of globally or locally `name` package. By default it checks if `name` exists as directory in [global-modules][] directory of the system. Pass `opts.local` to get path of `name` package from local directory or from `opts.cwd`. Returns rejected promise if module not found in global/local `node_modules` folder or if it exist but is not a directory.
 
 **Params**
@@ -97,6 +97,18 @@ getInstalledPath('global-modules', {
   console.log(path)
   // => '~/code/get-installed-path/node_modules/global-modules'
 })
+
+// When searching for the path of a package that is required
+// by several other packages, its path may not be in the
+// closest node_modules. In this case, to search recursively,
+// you can use the following:
+getInstalledPath('npm', {
+  paths: process.mainModule.paths
+}).then((path) => {
+  // ...
+})
+// `process.mainModule` refers to the location of the current
+// entry script.
 ```
 
 ### [.sync](index.js#L120)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ getInstalledPath('npm', {
 // entry script.
 ```
 
-### [.sync](index.js#L120)
+### [.sync](index.js#L136)
 > Get installed path of a `name` package synchronous.
 
 **Params**

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ const modules = require('global-modules')
  *   console.log(path)
  *   // => '~/code/get-installed-path/node_modules/global-modules'
  * })
- * 
+ *
  * // When searching for the path of a package that is required
  * // by several other packages, its path may not be in the
  * // closest node_modules. In this case, to search recursively,

--- a/test.js
+++ b/test.js
@@ -10,6 +10,7 @@
 'use strict'
 
 const fs = require('fs')
+const path = require('path')
 const test = require('mukla')
 const mkdirp = require('mkdirp')
 const getDir = require('pkg-dir')
@@ -173,4 +174,41 @@ test('async: should work for #5, not exists locally', () => {
     process.chdir(dirname)
     rimraf.sync('subdir')
   })
+})
+
+test('async: should support recursing directories (#11)', () => {
+  const targetModuleDir = path.resolve(__dirname, './node_modules/target-module')
+  const testModuleDir = path.resolve(__dirname, './node_modules/test-module')
+  mkdirp.sync(targetModuleDir)
+  mkdirp.sync(path.resolve(testModuleDir, './node_modules'))
+  fs.writeFileSync(
+    path.resolve(targetModuleDir, './package.json'),
+    JSON.stringify({ name: 'target-module' })
+  )
+  return getInstalledPath('target-module', {
+    paths: [
+      path.resolve(testModuleDir, './node_modules'),
+      path.resolve(__dirname, './node_modules')
+    ]
+  }).then((fp) => {
+    test.strictEqual(/\/node_modules\/target-module/.test(fp), true)
+  })
+})
+
+test('synchronous: should support recursing directories (#11)', () => {
+  const targetModuleDir = path.resolve(__dirname, './node_modules/target-module')
+  const testModuleDir = path.resolve(__dirname, './node_modules/test-module')
+  mkdirp.sync(targetModuleDir)
+  mkdirp.sync(path.resolve(testModuleDir, './node_modules'))
+  fs.writeFileSync(
+    path.resolve(targetModuleDir, './package.json'),
+    JSON.stringify({ name: 'target-module' })
+  )
+  const filepath = getInstalledPath.sync('target-module', {
+    paths: [
+      path.resolve(testModuleDir, './node_modules'),
+      path.resolve(__dirname, './node_modules')
+    ]
+  })
+  test.strictEqual(/\/node_modules\/target-module/.test(filepath), true)
 })


### PR DESCRIPTION
An attempt to address charlike/get-installed-path#11 by adding a new field to `opts`: `opts.paths`. By allowing a user to pass in an array of paths to search, `get-installed-path` can be extended to support many other methods of locating packages. I opted for the `process.mainModule.paths` example, which returns an array of node_modules paths that are _relevant_ to the current entry script.

It might contain an array of paths that looks like the following:

```javascript
[
    "/home/user/git/main/node_modules/sub/node_modules",
    "/home/user/git/main/node_modules",
    "/home/user/git/node_modules",
    "/home/user/node_modules",
    "/home/node_modules",
    "/node_modules"
]
```

Basically a predefined list of potential parent node_modules locations - perfect for use with `get-installed-path`.

The reason I need such a mechanism is that in some cases I have multiple projects using the same library which makes use of `get-installed-path`. Currently this system breaks due to npm optimising where the packages are installed (avoiding duplicates of course). Having this recursive behaviour would make this doable.

Fixes charlike/get-installed-path#11