### PR TITLE
Updating semantic-release to 8.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mukla": "0.4.9",
     "pkg-dir": "2.0.0",
     "rimraf": "2.6.2",
-    "semantic-release": "7.0.2"
+    "semantic-release": "^8.1.2"
   },
   "keywords": [
     "filepath",


### PR DESCRIPTION

Please update [semantic-release](https://npmjs.org/package/semantic-release) to version 8.1.2.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```8e9d9f7```](https://github.com/semantic-release/semantic-release/commit/8e9d9f77f3c7cc51764866a7348347cb4cb91d74) ```fix: Always pass pluginConfig to plugins as a defi&hellip;```
 * [```90417c6```](https://github.com/semantic-release/semantic-release/commit/90417c6ffe35c6ba479121a60085f0cfd35c6d1e) ```fix: Exit with 1 if unexpected error happens```
 * [```85dd69b```](https://github.com/semantic-release/semantic-release/commit/85dd69b3a240a328aeb14d1b9d2282bb70afa36c) ```feat: Retrieve version gitHead from git tags and unshallow the repo if necessary```
 * [```cbb51a4```](https://github.com/semantic-release/semantic-release/commit/cbb51a495b1dfd855d5bad92cd04872fb8961aa7) ```ci(codecov): Set default branch in codecov.yml```
 * [```a58d12d```](https://github.com/semantic-release/semantic-release/commit/a58d12d5e795238c6b588de180df3cfaec415caf) ```chore: Update badges```
 * [```42b3382```](https://github.com/semantic-release/semantic-release/commit/42b3382b0e08c6756478ee475c3c811ddf0a9762) ```ci(travis): Update .travis.yml```
 * [```cc3c8f2```](https://github.com/semantic-release/semantic-release/commit/cc3c8f25487e682228dd5f356be9e5358c7a5e1d) ```ci: Use codecov for code coverage```
 * [```abf92ad```](https://github.com/semantic-release/semantic-release/commit/abf92ad03ddcd7f81a56da7d89fc2466049d3ace) ```refactor: Use ES6, Test with AVA```
 * [```7fe0890```](https://github.com/semantic-release/semantic-release/commit/7fe0890350269ccc88a8afc3610609d5d9072659) ```chore: Remove editorconfig```
 * [```f10f157```](https://github.com/semantic-release/semantic-release/commit/f10f157d7989a2f763f96e0c1982bc48c72733be) ```chore: More generic `.gitignore` (Windows, Mac OS,&hellip;```
 * [```40e296b```](https://github.com/semantic-release/semantic-release/commit/40e296b00d54212363188e9351fc2ca3154ddc73) ```chore: Remove lockfiles```
 * [```266a3f7```](https://github.com/semantic-release/semantic-release/commit/266a3f72dcb2caf74ddd62dcc58d8898b3e18a71) ```chore: Add license file```
 * [```42456a3```](https://github.com/semantic-release/semantic-release/commit/42456a32b316c2879fc667323817c4cf11ee8e90) ```chore(package): update coveralls to version 3.0.0```
 * [```3a4334f```](https://github.com/semantic-release/semantic-release/commit/3a4334fbfdec6cdce985448b30145f87b326a3e6) ```fix(package): update @semantic-release/error to ve&hellip;```
 * [```41d9b7e```](https://github.com/semantic-release/semantic-release/commit/41d9b7e9848d554e80cc18ed703345def18c1d7e) ```docs: fix grammatical error in README```


See the full [change log](https://github.com/semantic-release/semantic-release/compare/0c79a9b4bffbaadb18923507c4084a232ca6e174...8e9d9f77f3c7cc51764866a7348347cb4cb91d74) for everything that changed in this release.